### PR TITLE
Fix to read.ncdfFlowSet: pd is now initialised before being referenced.

### DIFF
--- a/R/ncdfIO.R
+++ b/R/ncdfIO.R
@@ -172,8 +172,8 @@ read.ncdfFlowSet <- function(files = NULL
 	}
 	
 	if(!missing(phenoData)){
-		guids <- sampleNames(pd)
 		pd<-phenoData
+		guids <- sampleNames(pd)
 	}else{
 		guids <- basename(files)
 #		


### PR DESCRIPTION
pd was being referenced before being initialised.
This would lead to the following error when calling read.ncdFlowSet with the phenoData argument:

``` r
Error in sampleNames(pd) :
  error in evaluating the argument 'object' in selecting a method for
  function 'sampleNames': Error: object 'pd' not found
```

The fix involved simply swapping two lines around.
